### PR TITLE
Permit missing mail attribute

### DIFF
--- a/rapidconnect/app/rapid_connect.rb
+++ b/rapidconnect/app/rapid_connect.rb
@@ -182,7 +182,6 @@ class RapidConnect < Sinatra::Base
   def valid_subject?(subject)
     subject[:principal].present? &&
       subject[:cn].present? &&
-      subject[:mail].present? &&
       subject[:display_name].present?
   end
 

--- a/rapidconnect/spec/models/attributes_claim_spec.rb
+++ b/rapidconnect/spec/models/attributes_claim_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe AttributesClaim do
       .to eq('https://rapid.example.com!https://service.example.com!' \
              'ZgIn68qu5WHxfS94DhlveAhgY4o=')
   end
-  
+
   context 'when a legacy edupersontargetedid exists for the subject and service' do
     before do
       stub_redis = instance_double(Redis)

--- a/rapidconnect/spec/rapid_connect_spec.rb
+++ b/rapidconnect/spec/rapid_connect_spec.rb
@@ -228,7 +228,10 @@ describe RapidConnect do
         let(:invalid_headers) do
           dup_headers_and_remove_exisiting('HTTP_MAIL')
         end
-        include_examples 'halts invalid user session'
+        it 'does not halt session, continues' do
+          expect(last_response).to be_redirect
+          expect(last_response.location).not_to eq(invalid_session_target)
+        end
       end
 
       context 'missing displayname' do


### PR DESCRIPTION
This PR was already sent upstream as #110 and reviewed and accepted, but not merge (will be merged later).

In the meantime, we want to solve this issue for our users, so doing a separate PR of the same commits locally.

Gist of original PR is:
> We get the occasional support request from users who do not receive a `mail` attribute value from their IdP. These are primarily visitor/affiliate accounts where the underlying IdMS does not store a `mail` value for them.
>
> Currently, the `valid_subject?` method insists on `mail` attribute being present and halts the session.
> With #104 merged, the `mail` attribute is no longer strictly required for RapidConnect operation - it is no longer part of the EPTID retargeting.